### PR TITLE
Workaround by omit using super

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ is_binary(_ :: [{atom(), _}, ...])
 can never succeed.
 ```
 
+(run `mix dialyzer` for type checking)
+
 The offending code:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -39,3 +39,13 @@ defmodule ExceptionTypeExample do
   end
 end
 ```
+
+## Environment
+
+Tested on:
+
+```
+Erlang/OTP 28 [erts-16.0.1] [source] [64-bit] [smp:14:14] [ds:14:14:10] [async-threads:1] [jit]
+
+Elixir 1.18.4 (compiled with Erlang/OTP 28)
+```

--- a/lib/exception_type_example.ex
+++ b/lib/exception_type_example.ex
@@ -2,18 +2,17 @@ defmodule ExceptionTypeExample do
   @moduledoc """
   Documentation for `ExceptionTypeExample`.
   """
-
   defexception [:message, :other]
 
-  @impl true
+  @impl Exception
   def exception(binary_or_keyword)
 
   def exception(message) when is_binary(message) do
-    super(message: message, other: :other)
+    exception(message: message, other: :other)
   end
 
   def exception(attributes) when is_list(attributes) do
     attributes = Keyword.put(attributes, :other, :other)
-    super(attributes)
+    struct!(__MODULE__, attributes)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule ExceptionTypeExample.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "dialyxir": {:hex, :dialyxir, "1.4.5", "ca1571ac18e0f88d4ab245f0b60fa31ff1b12cbae2b11bd25d207f865e8ae78a", [:mix], [{:erlex, ">= 0.2.7", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b0fb08bb8107c750db5c0b324fa2df5ceaa0f9307690ee3c1f6ba5b9eb5d35c3"},
+  "erlex": {:hex, :erlex, "0.2.7", "810e8725f96ab74d17aac676e748627a07bc87eb950d2b83acd29dc047a30595", [:mix], [], "hexpm", "3ed95f79d1a844c3f6bf0cea61e0d5612a42ce56da9c03f01df538685365efb0"},
+}


### PR DESCRIPTION
Sorry, I kept thinking about this so needed to try it out :sweat-smile:

(this icnludes the dialyxir PR/ #2 as I needed a fast way to test it)

So, as best as I understand it, what dialyzer complains about here
is this [inside of defexception](https://github.com/elixir-lang/elixir/blob/7b20c281d521aa7aa2ad2baa1e9ae6c579d79d0c/lib/elixir/lib/kernel.ex#L5549C1-L5564C10):

```

      if Map.has_key?(struct, :message) do
        Elixir.Kernel.@(impl(true))

        def message(exception) do
          exception.message
        end

        defoverridable message: 1

        Elixir.Kernel.@(impl(true))

        def exception(msg) when Kernel.is_binary(msg) do
          exception(message: msg)
        end
      end
```

That is we define a clause featuring `is_binary` but we never
call that function with a binary. Another workaround that I
applied was to just have a catch all clause where I call it with
a binary. Not exactly elegant, but it worked.

That said, I also dislike `super` and lived most of my life
blissfully unaware of its existence until some point last year :D

So, this workaround foregoes the `super` call and instead we
kind of reimplement the original `def exception` but it's only
one line so I think that this is fine. I think dialyzer doesn't
see us calling the `super` and hence doesnt complain and hence
this is "fine".